### PR TITLE
Add elevated launch helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 add_compile_options(
     /permissive-
+    /EHsc
     /utf-8
     "$<$<CONFIG:Release>:/GL>"
     "$<$<CONFIG:Release>:/Gw>"
@@ -71,11 +72,25 @@ set(LOADER_RESOURCE ${RESOURCES_DIR}/loader.rc)
 add_executable(loader ${LOADER_SOURCES} ${LOADER_RESOURCE})
 target_include_directories(loader PRIVATE include)
 target_link_libraries(loader
+    PRIVATE bcrypt
     PRIVATE glaze::glaze
     PRIVATE WIL::WIL
     PRIVATE util
 )
-target_link_options(loader PRIVATE
+
+set(HELPER_SOURCES
+    src/helper/Main.cpp
+    src/loader/HelperProtocol.cpp
+)
+set(HELPER_RESOURCE ${RESOURCES_DIR}/loader.rc)
+add_executable(helper ${HELPER_SOURCES} ${HELPER_RESOURCE})
+target_include_directories(helper PRIVATE include)
+target_link_libraries(helper
+    PRIVATE glaze::glaze
+    PRIVATE WIL::WIL
+    PRIVATE util
+)
+target_link_options(helper PRIVATE
     /MANIFESTUAC:level='requireAdministrator'
 )
 

--- a/include/loader/HelperProtocol.hpp
+++ b/include/loader/HelperProtocol.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "loader/LaunchRequest.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace z3lx::loader {
+constexpr uint32_t helperProtocolMagic = 0x5A334C58;
+constexpr uint16_t helperProtocolVersion = 1;
+constexpr uint16_t helperRequestTypeLaunch = 1;
+
+struct HelperRequest {
+    uint32_t magic = helperProtocolMagic;
+    uint16_t version = helperProtocolVersion;
+    uint16_t type = helperRequestTypeLaunch;
+    uint64_t nonce = 0;
+    LaunchRequest launchRequest {};
+
+    [[nodiscard]] bool IsValid(uint64_t expectedNonce) const;
+
+    void Serialize(std::vector<uint8_t>& buffer) const;
+    void Deserialize(const std::vector<uint8_t>& buffer);
+};
+} // namespace z3lx::loader

--- a/include/loader/LaunchRequest.hpp
+++ b/include/loader/LaunchRequest.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace z3lx::loader {
+struct LaunchRequest {
+    std::filesystem::path gamePath {};
+    std::filesystem::path workingDirectory {};
+    std::string args {};
+    std::vector<std::filesystem::path> dllPaths {};
+    bool suspendLoad = false;
+};
+} // namespace z3lx::loader

--- a/include/util/win/LoaderInl.hpp
+++ b/include/util/win/LoaderInl.hpp
@@ -25,53 +25,6 @@ void LoadRemoteLibrary(
         return;
     }
 
-    // Adjust privileges
-    LUID luid {};
-    THROW_IF_WIN32_BOOL_FALSE(LookupPrivilegeValueA(
-        nullptr,
-        "SeDebugPrivilege", // SE_DEBUG_NAME 20L
-        &luid
-    ));
-
-    wil::unique_handle token {};
-    THROW_IF_WIN32_BOOL_FALSE(OpenProcessToken(
-        GetCurrentProcess(),
-        TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-        token.put()
-    ));
-
-    TOKEN_PRIVILEGES newPrivileges {
-        .PrivilegeCount = 1,
-        .Privileges = {{
-            .Luid = luid,
-            .Attributes = SE_PRIVILEGE_ENABLED
-        }}
-    };
-    TOKEN_PRIVILEGES oldPrivileges {};
-    DWORD returnLength = 0;
-    THROW_IF_WIN32_BOOL_FALSE(AdjustTokenPrivileges(
-        token.get(),
-        FALSE,
-        &newPrivileges,
-        sizeof(newPrivileges),
-        &oldPrivileges,
-        &returnLength
-    ));
-    const auto privilegesCleanup = wil::scope_exit([&] {
-        AdjustTokenPrivileges(
-            token.get(),
-            FALSE,
-            &oldPrivileges,
-            returnLength,
-            nullptr,
-            nullptr
-        );
-    });
-    THROW_WIN32_IF(
-        ERROR_PRIVILEGE_NOT_HELD,
-        GetLastError() == ERROR_NOT_ALL_ASSIGNED
-    );
-
     // Get LoadLibraryW
     const HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
     THROW_LAST_ERROR_IF_NULL(kernel32);

--- a/include/util/win/PipeMessage.hpp
+++ b/include/util/win/PipeMessage.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <Windows.h>
+
+namespace z3lx::util {
+std::vector<uint8_t> ReadPipeMessage(HANDLE pipe);
+
+void WritePipeMessage(
+    HANDLE pipe,
+    const std::vector<uint8_t>& buffer
+);
+} // namespace z3lx::util

--- a/src/helper/Main.cpp
+++ b/src/helper/Main.cpp
@@ -1,0 +1,114 @@
+#include "loader/HelperProtocol.hpp"
+#include "loader/LaunchRequest.hpp"
+#include "util/win/Loader.hpp"
+#include "util/win/PipeMessage.hpp"
+#include "util/win/String.hpp"
+
+#include <wil/resource.h>
+#include <wil/result.h>
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Windows.h>
+
+namespace z {
+using namespace z3lx::loader;
+using namespace z3lx::util;
+} // namespace z
+
+namespace {
+wil::unique_hfile ConnectPipe(const wchar_t* pipeName) {
+    HANDLE pipeHandle = CreateFileW(
+        pipeName,
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        nullptr,
+        OPEN_EXISTING,
+        0,
+        nullptr
+    );
+    THROW_LAST_ERROR_IF(pipeHandle == INVALID_HANDLE_VALUE);
+    return wil::unique_hfile { pipeHandle };
+}
+
+std::vector<uint8_t> ToBuffer(const char* text) {
+    const auto* begin = reinterpret_cast<const uint8_t*>(text);
+    return { begin, begin + std::strlen(text) };
+}
+
+uint64_t ParseNonce(const wchar_t* text) {
+    size_t index = 0;
+    const uint64_t nonce = std::stoull(text, &index, 16);
+    if (text[index] != L'\0') {
+        throw std::invalid_argument { "Invalid helper nonce" };
+    }
+    return nonce;
+}
+
+z::LaunchRequest ReadLaunchRequest(
+    const HANDLE pipe,
+    const uint64_t expectedNonce) {
+    z::HelperRequest request {};
+    request.Deserialize(z::ReadPipeMessage(pipe));
+    if (!request.IsValid(expectedNonce)) {
+        throw std::invalid_argument { "Invalid helper request" };
+    }
+    return request.launchRequest;
+}
+
+void StartGame(const z::LaunchRequest& request) {
+    std::wstring args {};
+    z::U8ToU16(request.args, args);
+
+    STARTUPINFOW si { .cb = sizeof(si) };
+    PROCESS_INFORMATION pi {};
+    THROW_IF_WIN32_BOOL_FALSE(CreateProcessW(
+        request.gamePath.c_str(),
+        args.data(),
+        nullptr,
+        nullptr,
+        FALSE,
+        request.suspendLoad ? CREATE_SUSPENDED : 0,
+        nullptr,
+        request.workingDirectory.c_str(),
+        &si,
+        &pi
+    ));
+    const wil::unique_handle process { pi.hProcess };
+    const wil::unique_handle thread { pi.hThread };
+
+    z::LoadRemoteLibrary(process.get(), request.dllPaths);
+    if (request.suspendLoad) {
+        ResumeThread(thread.get());
+    }
+}
+
+} // namespace
+
+int wmain(const int argc, wchar_t* argv[]) {
+    if (argc != 3) {
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    wil::unique_hfile pipe {};
+    try {
+        const uint64_t nonce = ParseNonce(argv[2]);
+        pipe = ConnectPipe(argv[1]);
+        StartGame(ReadLaunchRequest(pipe.get(), nonce));
+        z::WritePipeMessage(pipe.get(), {});
+        return 0;
+    } catch (const std::exception& e) {
+        if (pipe.is_valid()) {
+            try {
+                z::WritePipeMessage(pipe.get(), ToBuffer(e.what()));
+            } catch (...) {}
+        }
+        return 1;
+    }
+}

--- a/src/loader/HelperProtocol.cpp
+++ b/src/loader/HelperProtocol.cpp
@@ -1,0 +1,48 @@
+#include "loader/HelperProtocol.hpp"
+
+#include <glaze/glaze.hpp>
+#include <glaze/glaze_exceptions.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace {
+constexpr glz::opts opts {
+    .null_terminated = false,
+    .comments = false,
+    .error_on_unknown_keys = true,
+    .skip_null_members = false,
+    .prettify = true,
+    .minified = false,
+    .indentation_char = ' ',
+    .indentation_width = 4,
+    .new_lines_in_arrays = true,
+    .append_arrays = false,
+    .error_on_missing_keys = true,
+    .error_on_const_read = true,
+    .bools_as_numbers = false,
+    .quoted_num = false,
+    .number = false,
+    .raw = false,
+    .raw_string = false,
+    .structs_as_arrays = false,
+    .partial_read = false
+};
+} // namespace
+
+namespace z3lx::loader {
+bool HelperRequest::IsValid(const uint64_t expectedNonce) const {
+    return magic == helperProtocolMagic &&
+        version == helperProtocolVersion &&
+        type == helperRequestTypeLaunch &&
+        nonce == expectedNonce;
+}
+
+void HelperRequest::Serialize(std::vector<uint8_t>& buffer) const {
+    glz::ex::write<opts>(*this, buffer);
+}
+
+void HelperRequest::Deserialize(const std::vector<uint8_t>& buffer) {
+    glz::ex::read<opts>(*this, buffer);
+}
+} // namespace z3lx::loader

--- a/src/loader/Main.cpp
+++ b/src/loader/Main.cpp
@@ -1,10 +1,13 @@
 #include "common/Constants.hpp"
 #include "loader/Config.hpp"
+#include "loader/HelperProtocol.hpp"
+#include "loader/LaunchRequest.hpp"
 #include "util/Type.hpp"
 #include "util/Version.hpp"
 #include "util/win/Dialogue.hpp"
 #include "util/win/File.hpp"
 #include "util/win/Loader.hpp"
+#include "util/win/PipeMessage.hpp"
 #include "util/win/Shell.hpp"
 #include "util/win/String.hpp"
 #include "util/win/Version.hpp"
@@ -27,6 +30,7 @@
 #include <print>
 #include <ranges>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -34,6 +38,8 @@
 #include <vector>
 
 #include <Windows.h>
+#include <bcrypt.h>
+#include <shellapi.h>
 
 namespace fs = std::filesystem;
 namespace z {
@@ -179,7 +185,78 @@ void CheckCompatibility(
     }
 }
 
-void StartGame(const z::Config& config) {
+std::wstring GetPipeName() {
+    return std::format(
+        LR"(\\.\pipe\genshin-unlock-{}-{}-{})",
+        GetCurrentProcessId(),
+        GetCurrentThreadId(),
+        GetTickCount64()
+    );
+}
+
+wil::unique_hfile CreatePipe(const std::wstring& pipeName) {
+    HANDLE pipeHandle = CreateNamedPipeW(
+        pipeName.c_str(),
+        PIPE_ACCESS_DUPLEX,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT,
+        1,
+        64 * 1024,
+        64 * 1024,
+        0,
+        nullptr
+    );
+    THROW_LAST_ERROR_IF(pipeHandle == INVALID_HANDLE_VALUE);
+    return wil::unique_hfile { pipeHandle };
+}
+
+void WaitForPipeConnection(
+    const HANDLE pipe,
+    const HANDLE helperProcess,
+    const std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (true) {
+        const BOOL connected = ConnectNamedPipe(pipe, nullptr);
+        const DWORD error = GetLastError();
+        if (connected || error == ERROR_PIPE_CONNECTED) {
+            DWORD mode = PIPE_READMODE_BYTE | PIPE_WAIT;
+            THROW_IF_WIN32_BOOL_FALSE(SetNamedPipeHandleState(
+                pipe,
+                &mode,
+                nullptr,
+                nullptr
+            ));
+            return;
+        }
+        THROW_WIN32_IF(error, error != ERROR_PIPE_LISTENING);
+
+        THROW_WIN32_IF(
+            ERROR_BROKEN_PIPE,
+            WaitForSingleObject(helperProcess, 0) == WAIT_OBJECT_0
+        );
+        THROW_WIN32_IF(
+            WAIT_TIMEOUT,
+            std::chrono::steady_clock::now() >= deadline
+        );
+        std::this_thread::sleep_for(std::chrono::milliseconds { 50 });
+    }
+}
+
+uint64_t CreateNonce() {
+    uint64_t nonce = 0;
+    THROW_IF_NTSTATUS_FAILED(BCryptGenRandom(
+        nullptr,
+        reinterpret_cast<PUCHAR>(&nonce),
+        sizeof(nonce),
+        BCRYPT_USE_SYSTEM_PREFERRED_RNG
+    ));
+    return nonce;
+}
+
+std::wstring FormatNonce(const uint64_t nonce) {
+    return std::format(L"{:016X}", nonce);
+}
+
+z::LaunchRequest CreateLaunchRequest(const z::Config& config) {
     std::wstring args = [&config] {
         if (!config.overrideArgs) {
             return std::wstring {};
@@ -217,26 +294,57 @@ void StartGame(const z::Config& config) {
         );
     }();
 
-    STARTUPINFOW si { .cb = sizeof(si) };
-    PROCESS_INFORMATION pi {};
-    THROW_IF_WIN32_BOOL_FALSE(CreateProcessW(
-        config.gamePath.c_str(),
-        args.data(),
-        nullptr,
-        nullptr,
-        FALSE,
-        config.suspendLoad ? CREATE_SUSPENDED : 0,
-        nullptr,
-        config.gamePath.parent_path().c_str(),
-        &si,
-        &pi
-    ));
-    const wil::unique_handle process { pi.hProcess };
-    const wil::unique_handle thread { pi.hThread };
+    z::LaunchRequest request {
+        .gamePath = config.gamePath,
+        .workingDirectory = config.gamePath.parent_path(),
+        .dllPaths = config.dllPaths,
+        .suspendLoad = config.suspendLoad
+    };
+    z::U16ToU8(args, request.args);
+    return request;
+}
 
-    z::LoadRemoteLibrary(process.get(), config.dllPaths);
-    if (config.suspendLoad) {
-        ResumeThread(thread.get());
+void RunPrivilegedHelper(const z::LaunchRequest& launchRequest) {
+    const std::filesystem::path currentPath =
+        z::GetCurrentModuleFilePath().parent_path();
+    const std::filesystem::path helperPath = currentPath / "helper.exe";
+    const std::wstring pipeName = GetPipeName();
+    const uint64_t nonce = CreateNonce();
+    const std::wstring nonceText = FormatNonce(nonce);
+    const std::wstring parameters = std::format(L"{} {}", pipeName, nonceText);
+    const wil::unique_hfile pipe = CreatePipe(pipeName);
+
+    SHELLEXECUTEINFOW sei {
+        .cbSize = sizeof(sei),
+        .fMask = SEE_MASK_NOCLOSEPROCESS,
+        .lpVerb = L"runas",
+        .lpFile = helperPath.c_str(),
+        .lpParameters = parameters.c_str(),
+        .lpDirectory = currentPath.c_str(),
+        .nShow = SW_SHOWNORMAL
+    };
+    THROW_IF_WIN32_BOOL_FALSE(ShellExecuteExW(&sei));
+    const wil::unique_handle helperProcess { sei.hProcess };
+
+    WaitForPipeConnection(
+        pipe.get(),
+        helperProcess.get(),
+        std::chrono::seconds { 30 }
+    );
+
+    const z::HelperRequest helperRequest {
+        .nonce = nonce,
+        .launchRequest = launchRequest
+    };
+    std::vector<uint8_t> request {};
+    helperRequest.Serialize(request);
+    z::WritePipeMessage(pipe.get(), request);
+
+    const std::vector<uint8_t> response = z::ReadPipeMessage(pipe.get());
+    if (!response.empty()) {
+        throw std::runtime_error {
+            std::string { response.begin(), response.end() }
+        };
     }
 }
 } // namespace
@@ -335,7 +443,7 @@ int main() try {
     }
 
     std::println(std::cout, "Starting game process...");
-    StartGame(config);
+    RunPrivilegedHelper(CreateLaunchRequest(config));
     std::println(std::cout, "Game process started successfully");
     std::this_thread::sleep_for(std::chrono::seconds { 1 });
 

--- a/src/util/win/PipeMessage.cpp
+++ b/src/util/win/PipeMessage.cpp
@@ -1,0 +1,56 @@
+#include "util/win/PipeMessage.hpp"
+
+#include <wil/result.h>
+
+#include <cstdint>
+
+#include <Windows.h>
+
+namespace z3lx::util {
+std::vector<uint8_t> ReadPipeMessage(const HANDLE pipe) {
+    uint32_t size = 0;
+    DWORD bytesRead = 0;
+    THROW_IF_WIN32_BOOL_FALSE(ReadFile(
+        pipe,
+        &size,
+        sizeof(size),
+        &bytesRead,
+        nullptr
+    ));
+
+    std::vector<uint8_t> buffer(size);
+    if (!buffer.empty()) {
+        THROW_IF_WIN32_BOOL_FALSE(ReadFile(
+            pipe,
+            buffer.data(),
+            size,
+            &bytesRead,
+            nullptr
+        ));
+    }
+    return buffer;
+}
+
+void WritePipeMessage(
+    const HANDLE pipe,
+    const std::vector<uint8_t>& buffer) {
+    const uint32_t size = static_cast<uint32_t>(buffer.size());
+    DWORD bytesWritten = 0;
+    THROW_IF_WIN32_BOOL_FALSE(WriteFile(
+        pipe,
+        &size,
+        sizeof(size),
+        &bytesWritten,
+        nullptr
+    ));
+    if (!buffer.empty()) {
+        THROW_IF_WIN32_BOOL_FALSE(WriteFile(
+            pipe,
+            buffer.data(),
+            size,
+            &bytesWritten,
+            nullptr
+        ));
+    }
+}
+} // namespace z3lx::util


### PR DESCRIPTION
## Summary

This PR moves the administrator-only game launch and DLL injection work out of
`loader.exe` and into a separate elevated `helper.exe` process.

`loader.exe` remains the normal user-facing entry point. It now reads and
validates configuration, creates a one-shot named pipe, launches `helper.exe`
with `ShellExecuteExW(runas)`, and sends a nonce-checked launch request over the
pipe.

`helper.exe` carries the `requireAdministrator` manifest, starts the game
process, loads the configured DLLs, resumes the game thread when needed, and
then exits.

## Motivation

This is intended to reduce Windows Defender false positives on the main
launcher executable by isolating the high-privilege injection behavior into a
small helper binary.

The current upstream 6.6.0 release is detected by Windows Defender Antivirus as:

```text
Behavior:Win32/DefenseEvasion.A!ml
```

Observed environment:

```text
Windows Defender security intelligence version: 1.451.29.0
```

With this PR applied, the rebuilt release artifacts are no longer detected by
Windows Defender in that environment.

## VirusTotal Results

The rebuilt `loader.exe` is no longer detected on VirusTotal:

```text
loader.exe: 0/71
```

VirusTotal report:

https://www.virustotal.com/gui/file/8bf319983a88c8a7cd28ed5b67c16734b6502b96018a70ba33748588ee749153

The newly added `helper.exe` is still flagged by a small number of vendors, but
it is not detected or removed by Windows Defender in the tested environment:

```text
helper.exe: 3/70
```

VirusTotal report:

https://www.virustotal.com/gui/file/4cea4add7e1bdb5b9fb5d3a4a079a3690aab0a6c5ba124efb21f338fcbb1725b

## Implementation Details

- Adds a new `helper.exe` target.
- Moves the `requireAdministrator` manifest from `loader.exe` to `helper.exe`.
- Adds a small helper IPC protocol using a length-prefixed named pipe message.
- Adds a random nonce to bind the helper request to the launcher instance.
- Keeps `loader.exe` unelevated during configuration and compatibility checks.
- Links `loader.exe` with `bcrypt` for nonce generation.
- Enables `/EHsc` because the project uses `WIL_EXCEPTION_MODE=1`, which
  requires C++ exception handling under MSVC.